### PR TITLE
[BE] 경도와 위도의 x좌표 및 y좌표 구분이 잘못된 부분을 수정한다

### DIFF
--- a/BE/src/main/java/com/codesquad/dust4/api/DustAPIController.java
+++ b/BE/src/main/java/com/codesquad/dust4/api/DustAPIController.java
@@ -25,14 +25,14 @@ public class DustAPIController {
 
   @GetMapping("/dust-status")
 
-  public ResponseEntity<DustInfoByStationDto> getDustInfo(@RequestParam("latitude") String latitude, @RequestParam("longitude") String longitude)
+  public ResponseEntity<DustInfoByStationDto> getDustInfo(@RequestParam("latitude") String EPSGlongitude, @RequestParam("longitude") String EPSGlatitude)
       throws IOException, ExecutionException, InterruptedException {
-    logger.info("latitude: {}, longitude: {}", latitude, longitude);
+    logger.info("longitude: {}, latitude: {}", EPSGlongitude, EPSGlatitude);
 
-    LocationReturnDto locationReturnDto = LocationConverterUtil.locationConverter(latitude, longitude);
+    LocationReturnDto locationReturnDto = LocationConverterUtil.locationConverter(EPSGlongitude, EPSGlatitude);
 
-    String tmX = locationReturnDto.getLatitude();
-    String tmY = locationReturnDto.getLongitude();
+    String tmX = locationReturnDto.getLongitude();
+    String tmY = locationReturnDto.getLatitude();
 
     DustInfoByStationDto dustInfoByStationDto = DustStatusPublicApi.dustStatus(tmX, tmY);
 

--- a/BE/src/main/java/com/codesquad/dust4/utils/LocationConverterUtil.java
+++ b/BE/src/main/java/com/codesquad/dust4/utils/LocationConverterUtil.java
@@ -25,8 +25,8 @@ public class LocationConverterUtil {
     ArrayList<String> parsedLocation = ParseJSONDataUtil.parseLocationJSON(receivedTmLocation);
 
     LocationReturnDto locationReturnDto = new LocationReturnDto();
-    locationReturnDto.setLatitude(parsedLocation.get(0));
-    locationReturnDto.setLongitude(parsedLocation.get(1));
+    locationReturnDto.setLongitude(parsedLocation.get(0));
+    locationReturnDto.setLatitude(parsedLocation.get(1));
 
     return locationReturnDto;
   }


### PR DESCRIPTION
## 변경 사항
* latitude(경도)는 x좌표이고 longitude(위도)는 y좌표인데, 경도를 y좌표라고 설정하고 위도를 x좌표라고 구현하는 오류가 있었고 이를 수정함.
* 표준 GPS 좌표계에 따라 EPSG 기준 위도 및 경도 데이터가 넘어오는 변수에 EPSG라고 명시함